### PR TITLE
Refactor Investment Calculator

### DIFF
--- a/08-investment-calculator/src/App.jsx
+++ b/08-investment-calculator/src/App.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import Header from "./components/Header/Header";
 import UserInput from "./components/UserInput/UserInput";
 import Results from "./components/Results/Results";
 
@@ -27,7 +26,6 @@ const App = () => {
 
   return (
     <>
-      <Header />
       <div id="user-input">
         <UserInput inputHandler={handleChange} userInputState={userInput} />
       </div>

--- a/08-investment-calculator/src/components/InputGroup/InputGroup.jsx
+++ b/08-investment-calculator/src/components/InputGroup/InputGroup.jsx
@@ -1,0 +1,19 @@
+const InputGroup = ({ name, inputHandler, value, identifier }) => {
+  return (
+    <div className="input-group">
+      <p>
+        <label>{name}</label>
+        <input
+          name={name}
+          type="number"
+          onChange={(event) =>
+            inputHandler(identifier, event.target.value)
+          }
+          value={value}
+        />
+      </p>
+    </div>
+  );
+};
+
+export default InputGroup

--- a/08-investment-calculator/src/components/Results/Results.jsx
+++ b/08-investment-calculator/src/components/Results/Results.jsx
@@ -12,6 +12,26 @@ const Results = ({ userInputState }) => {
 
   console.log(resultsData);
 
+  const renderBodyElements = () => {
+    return resultsData.map((yearData) => {
+        const totalInterest =
+          yearData.valueEndOfYear -
+          yearData.annualInvestment * yearData.year -
+          initialInvestment;
+        const totalAmountInvested = yearData.valueEndOfYear - totalInterest;
+
+        return (
+          <tr key={yearData.year}>
+            <td>{yearData.year}</td>
+            <td>{formatter.format(yearData.valueEndOfYear)}</td>
+            <td>{formatter.format(yearData.interest)}</td>
+            <td>{formatter.format(totalInterest)}</td>
+            <td>{formatter.format(totalAmountInvested)}</td>
+          </tr>
+        );
+      })
+  }
+
   return (
     <table id="result">
       <thead>
@@ -24,23 +44,7 @@ const Results = ({ userInputState }) => {
         </tr>
       </thead>
       <tbody>
-        {resultsData.map((yearData) => {
-          const totalInterest =
-            yearData.valueEndOfYear -
-            yearData.annualInvestment * yearData.year -
-            initialInvestment;
-          const totalAmountInvested = yearData.valueEndOfYear - totalInterest;
-
-          return (
-            <tr key={yearData.year}>
-              <td>{yearData.year}</td>
-              <td>{formatter.format(yearData.valueEndOfYear)}</td>
-              <td>{formatter.format(yearData.interest)}</td>
-              <td>{formatter.format(totalInterest)}</td>
-              <td>{formatter.format(totalAmountInvested)}</td>
-            </tr>
-          );
-        })}
+        {renderBodyElements()}
       </tbody>
     </table>
   );

--- a/08-investment-calculator/src/components/Results/Results.jsx
+++ b/08-investment-calculator/src/components/Results/Results.jsx
@@ -4,33 +4,38 @@ import {
 } from "../../util/investment.js";
 const Results = ({ userInputState }) => {
   const resultsData = calculateInvestmentResults(userInputState);
+  const initialYear = resultsData[0];
 
   const initialInvestment =
-    resultsData[0].valueEndOfYear -
-    resultsData[0].interest -
-    resultsData[0].annualInvestment;
+    initialYear.valueEndOfYear -
+    initialYear.interest -
+    initialYear.annualInvestment;
 
-  console.log(resultsData);
+//   console.log(resultsData);
 
   const renderBodyElements = () => {
     return resultsData.map((yearData) => {
-        const totalInterest =
-          yearData.valueEndOfYear -
-          yearData.annualInvestment * yearData.year -
-          initialInvestment;
-        const totalAmountInvested = yearData.valueEndOfYear - totalInterest;
+      const { year, interest, valueEndOfYear, annualInvestment } = yearData;
 
-        return (
-          <tr key={yearData.year}>
-            <td>{yearData.year}</td>
-            <td>{formatter.format(yearData.valueEndOfYear)}</td>
-            <td>{formatter.format(yearData.interest)}</td>
-            <td>{formatter.format(totalInterest)}</td>
-            <td>{formatter.format(totalAmountInvested)}</td>
-          </tr>
-        );
-      })
-  }
+      const totalInterest = valueEndOfYear - annualInvestment * year - initialInvestment;
+      const totalAmountInvested = valueEndOfYear - totalInterest;
+
+      const formattedEndOfYear = formatter.format(valueEndOfYear);
+      const formattedInterest = formatter.format(interest);
+      const formattedTotalInterest = formatter.format(totalInterest);
+      const formattedTotalAmountInvested = formatter.format(totalAmountInvested);
+
+      return (
+        <tr key={year}>
+          <td>{year}</td>
+          <td>{formattedEndOfYear}</td>
+          <td>{formattedInterest}</td>
+          <td>{formattedTotalInterest}</td>
+          <td>{formattedTotalAmountInvested}</td>
+        </tr>
+      );
+    });
+  };
 
   return (
     <table id="result">
@@ -43,9 +48,7 @@ const Results = ({ userInputState }) => {
           <th>Invested Capital</th>
         </tr>
       </thead>
-      <tbody>
-        {renderBodyElements()}
-      </tbody>
+      <tbody>{renderBodyElements()}</tbody>
     </table>
   );
 };

--- a/08-investment-calculator/src/components/UserInput/UserInput.jsx
+++ b/08-investment-calculator/src/components/UserInput/UserInput.jsx
@@ -1,56 +1,31 @@
+import InputGroup from "../InputGroup/InputGroup";
+
 const UserInput = ({ inputHandler, userInputState }) => {
+  const { initialInvestment, annualInvestment, expectedReturn, duration } =
+    userInputState;
+
+    // Honestly i'd probably go with repeating the declarations for each input group, or not even going this far into a refactor at all. Curious if this is a common pattern.
+  const renderInputGroups = () => {
+    return Object.entries(userInputState).map(([key, value]) => {
+      const derivedName = key.replace(/([a-z])([A-Z])/g, "$1 $2");
+
+      return (
+        <InputGroup
+          name={derivedName}
+          inputHandler={inputHandler}
+          value={value}
+          identifier={key}
+        />
+      );
+    });
+  };
   return (
     <section id="user-input">
-      <div className="input-group">
-        <p>
-          <label>Initial Investment</label>
-          <input
-            name="Initial Investment"
-            type="number"
-            onChange={(event) =>
-              inputHandler("initialInvestment", event.target.value)
-            }
-            value={userInputState.initialInvestment}
-          />
-        </p>
-      </div>
-      <div className="input-group">
-        <p>
-          <label>Annual Investment</label>
-          <input
-            name="Annual Investment"
-            type="number"
-            onChange={(event) =>
-              inputHandler("annualInvestment", event.target.value)
-            }
-            value={userInputState.annualInvestment}
-          />
-        </p>
-      </div>
-      <div className="input-group">
-        <p>
-          <label>Expected Return</label>
-          <input
-            name="Expected Return"
-            type="number"
-            onChange={(event) =>
-              inputHandler("expectedReturn", event.target.value)
-            }
-            value={userInputState.expectedReturn}
-          />
-        </p>
-      </div>
-      <div className="input-group">
-        <p>
-          <label>duration</label>
-          <input
-            name="duration"
-            type="number"
-            onChange={(event) => inputHandler("duration", event.target.value)}
-            value={userInputState.duration}
-          />
-        </p>
-      </div>
+      {/* <InputGroup name={'Initial Investment'} inputHandler={inputHandler} value={initialInvestment} identifier='initialInvestment'/>
+      <InputGroup name={'Annual Investment'} inputHandler={inputHandler} value={annualInvestment} identifier='annualInvestment'/>
+      <InputGroup name={'Expected Return'} inputHandler={inputHandler} value={expectedReturn} identifier='expectedReturn'/>
+      <InputGroup name={'Duration'} inputHandler={inputHandler} value={duration} identifier='duration'/> */}
+      {renderInputGroups()}
     </section>
   );
 };

--- a/08-investment-calculator/src/components/UserInput/UserInput.jsx
+++ b/08-investment-calculator/src/components/UserInput/UserInput.jsx
@@ -1,8 +1,8 @@
 import InputGroup from "../InputGroup/InputGroup";
 
 const UserInput = ({ inputHandler, userInputState }) => {
-  const { initialInvestment, annualInvestment, expectedReturn, duration } =
-    userInputState;
+  // const { initialInvestment, annualInvestment, expectedReturn, duration } =
+  //   userInputState;
 
     // Honestly i'd probably go with repeating the declarations for each input group, or not even going this far into a refactor at all. Curious if this is a common pattern.
   const renderInputGroups = () => {

--- a/08-investment-calculator/src/index.jsx
+++ b/08-investment-calculator/src/index.jsx
@@ -2,10 +2,12 @@ import ReactDOM from "react-dom/client";
 import { StrictMode } from "react";
 
 import App from "./App.jsx";
+import Header from "./components/Header/Header";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <StrictMode>
+    <Header />
     <App />
   </StrictMode>
 );


### PR DESCRIPTION
This PR contains several refactors to the completed Investment Calculator project. These refactors are low-hanging fruit, as I'm mostly practicing the skill to notice when/where changes can be made.

I have two main questions. The first is moving the `<Header />` component to the entrypoint `index.jsx`. My thought process was

> 'Every time I change any input, the entire app gets re-rendered, including the Header! This happens because the header is part of the App Component function. So, moving the header to the root index.js file will take care of that. Since the header is simple, it can live in `index.js`'

Is this a reasonable assertion? Are there cases where you wouldn't want anything in the entrypoint, BUT `<App />` itself?

Next, in commit where I [attempt to programmatically generate InputGroups](https://github.com/jmclean-coder/React/commit/c00145b15932f1ed1c89d23c55160479ee2f40fd). I understand the pattern of using an Identifier in my `handleChange` functions. However, I'm used to working in the context of a `<form />` element and making reusable components, so most often, I've used named Inputs over an identifier. 

After I figured out how to do it with `Object.entries` a map, and some regex string manipulation. I asked, 'In what case would it be worth it to do it like this? instead of just repeating the similar, yet different `<InputGroup />` declarations?' I'm curious to know your thoughts about this.






